### PR TITLE
Add www.poewiki.net support and update readme to new wiki

### DIFF
--- a/PoE_All_Ears_Wiki_Tracker.user.js
+++ b/PoE_All_Ears_Wiki_Tracker.user.js
@@ -6,6 +6,7 @@
 // @author       halfacandan
 // @match        https://pathofexile.gamepedia.com/All_Ears*
 // @match        https://pathofexile.fandom.com/wiki/All_Ears*
+// @match        https://www.poewiki.net/wiki/All_Ears*
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js
 // @require      https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js
 // @grant        GM.setValue
@@ -16,7 +17,7 @@
     'use strict';
 
     async function updateAchievementCount(action,id){
-        
+
       	switch(action) {
           case "add":
             completedAchievements.push(id);
@@ -31,9 +32,9 @@
             // "remove"
             removeArrayValue(completedAchievements,id);
         }
-      
+
       	redrawAchievementCount();
-      
+
         await setAchievements(completedAchievements);
     }
 
@@ -90,7 +91,7 @@
     let completedAchievements = await getAchievements();
     var achievements = $("table.wikitable:not(table.responsive-table) tr:not(:nth-child(1)) td:nth-child(1)");
     var achievementIds = [];
-  
+
   	var jQueryUiStylesheetUri = "https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css";
 
     // Filter out rowspan issues
@@ -113,7 +114,7 @@
             #colourBlindModeLabel{ font-size: 70%; }
             #resetButton { font-size: 70%; margin-top: 13px; }
           </style>`).appendTo("head");
-      
+
       	$(`<link rel="stylesheet" href="${jQueryUiStylesheetUri}">`).appendTo("head");
 
         $(`<div id="achievementCounter">

--- a/PoE_No_Stone_Unturned_Wiki_Tracker.user.js
+++ b/PoE_No_Stone_Unturned_Wiki_Tracker.user.js
@@ -6,6 +6,7 @@
 // @author       halfacandan
 // @match        https://pathofexile.gamepedia.com/No_Stone_Unturned*
 // @match        https://pathofexile.fandom.com/wiki/No_Stone_Unturned*
+// @match        https://www.poewiki.net/wiki/No_Stone_Unturned*
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js
 // @require      https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js
 // @grant        GM.setValue
@@ -16,7 +17,7 @@
     'use strict';
 
     async function updateLoreCount(action,id){
-      
+
         switch(action) {
           case "add":
             completedLores.push(id);
@@ -30,7 +31,7 @@
           default:
             // "remove"
             removeArrayValue(completedLores,id);
-        } 
+        }
 
       	redrawLoreCount();
 
@@ -82,13 +83,13 @@
 
         await GM.setValue('poe_lores', completedLores.join(","));
     }
-  
+
 		var colourBlindMode = await GM.getValue('colourBlindMode', true);
     var completedLores = await getLores();
     var lores = $("table.wikitable:not(table.wikitable:eq(0),table.responsive-table) tbody tr td:nth-child(1)");
 
   	var jQueryUiStylesheetUri = "https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css";
-    
+
     $(document).ready(function(){
 
         $(`<style type='text/css'>
@@ -99,7 +100,7 @@
             #colourBlindModeLabel{ font-size: 70%; }
             #resetButton { font-size: 70%; margin-top: 13px; }
         </style>`).appendTo("head");
-      	
+
       	$(`<link rel="stylesheet" href="${jQueryUiStylesheetUri}">`).appendTo("head");
 
         $(`<div id="loreCounter">

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This project hosts a few user scripts which can enhance Path of Exile's communit
 User scripts are small pieces of JavaScript code which run in a browser extension and manipulate whichever webpages they target.
 
 If you know what you are doing then you can use the links below to install the scripts...if not, read on:
-* [PoE All Ears Wiki Tracker](https://github.com/halfacandan/PoEUserScripts/raw/main/PoE_All_Ears_Wiki_Tracker.user.js) - Let's you track which objectives for the "All Ears" achievement have been completed on the [PoE Wiki "All Ears" page](https://pathofexile.fandom.com/wiki/All_Ears)
-* [PoE No Stone Unturned Wiki Tracker](https://github.com/halfacandan/PoEUserScripts/raw/main/PoE_No_Stone_Unturned_Wiki_Tracker.user.js) - Let's you track which objectives for the "No Stone Unturned" achievement have been completed on the [PoE Wiki "No Stone Unturned" page](https://pathofexile.fandom.com/wiki/No_Stone_Unturned)
+* [PoE All Ears Wiki Tracker](https://github.com/halfacandan/PoEUserScripts/raw/main/PoE_All_Ears_Wiki_Tracker.user.js) - Let's you track which objectives for the "All Ears" achievement have been completed on the [PoE Wiki "All Ears" page](https://www.poewiki.net/wiki/All_Ears)
+* [PoE No Stone Unturned Wiki Tracker](https://github.com/halfacandan/PoEUserScripts/raw/main/PoE_No_Stone_Unturned_Wiki_Tracker.user.js) - Let's you track which objectives for the "No Stone Unturned" achievement have been completed on the [PoE Wiki "No Stone Unturned" page](https://www.poewiki.net/wiki/No_Stone_Unturned)
 
 ## Installation Instructions
 
@@ -19,8 +19,8 @@ Alternatively you can follow these steps to get up and running:
     * [PoE All Ears Wiki Tracker](https://github.com/halfacandan/PoEUserScripts/raw/main/PoE_All_Ears_Wiki_Tracker.user.js)
     * [PoE No Stone Unturned Wiki Tracker](https://github.com/halfacandan/PoEUserScripts/raw/main/PoE_No_Stone_Unturned_Wiki_Tracker.user.js)
 3. Visit the PoE Wiki:
-    * [PoE Wiki "All Ears" page](https://pathofexile.fandom.com/wiki/All_Ears)
-    * [PoE Wiki "No Stone Unturned" page](https://pathofexile.fandom.com/wiki/No_Stone_Unturned)
+    * [PoE Wiki "All Ears" page](https://www.poewiki.net/wiki/All_Ears)
+    * [PoE Wiki "No Stone Unturned" page](https://www.poewiki.net/wiki/No_Stone_Unturned)
 
 ## Credits
 


### PR DESCRIPTION
The Fandom wiki is outdated, and no longer considered the "official" PoE wiki. The new kid on the block is https://www.poewiki.net/.

I've been testing your userscript using poewiki.net and everything is working great.

![image](https://user-images.githubusercontent.com/2153486/168501104-33b1847e-da09-4eed-a763-4e545f689b75.png)

Thanks so much for your work! :)